### PR TITLE
fix: fix bug with modernbert

### DIFF
--- a/skeletoken/base.py
+++ b/skeletoken/base.py
@@ -77,8 +77,6 @@ class TokenizerModel(BaseModel):
 
     def model_post_init(self, __context: dict[Any, Any]) -> None:  # noqa: C901
         """Post-initialization processing."""
-        # Helper for context. To be consolidated somewhere
-        self._original_tokenizer = self.deep_copy()
         # Add any missing added tokens to the vocabulary.
         # Sort to fill up the vocabulary in order.
         for token in sorted(self.added_tokens.root, key=lambda x: x.id):
@@ -144,6 +142,8 @@ class TokenizerModel(BaseModel):
                     rstrip=True,
                 )
             self.pad_token = pad_token
+
+        self._original_tokenizer = self.deep_copy()
 
     @property
     def preprocessor(self) -> Preprocessor:

--- a/tests/integration/test_modernbert_base.py
+++ b/tests/integration/test_modernbert_base.py
@@ -190,6 +190,21 @@ def test_prune_added_tokens() -> None:
     call_tokenizer(pruned)
 
 
+def test_prune_added_tokens_model_delta_maps_surviving_special_tokens() -> None:
+    """Test that surviving special tokens map back to their pre-prune ids instead of being treated as new."""
+    model = TokenizerModel.from_pretrained(_PATH)
+    original_ids = {content: model.vocabulary[content] for content in ("[UNK]", "[CLS]", "[SEP]", "[PAD]")}
+
+    pruned = model.prune_added_tokens()
+    delta = pruned.model_delta
+    assert delta.new_tokens == {}
+    assert len(delta.token_mapping) == pruned.vocabulary_size
+
+    for content, original_id in original_ids.items():
+        new_id = pruned.vocabulary[content]
+        assert delta.token_mapping[new_id] == original_id
+
+
 def test_added_tokens_ids_consistent_after_add() -> None:
     """Test that all existing added tokens still have correct IDs after adding a new one."""
     model = TokenizerModel.from_pretrained(_PATH)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -775,9 +775,9 @@ def test_model_delta(small_tokenizer: Tokenizer) -> None:
     model.unk_token = "new_unk"
     model.pad_token = "[PAD]"
     delta = model.model_delta
-    assert delta.token_mapping == {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 6: 7, 7: 8, 8: 9}
+    assert delta.token_mapping == {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 6: 7, 7: 8, 8: 9, 9: 10}
     assert delta.new_vocabulary_size == 13
-    assert delta.new_tokens == {"x": 5, "[ADDED]": 11, "new_token": 10, "new_unk": 12, "F": 9}
+    assert delta.new_tokens == {"x": 5, "[ADDED]": 11, "new_token": 10, "new_unk": 12}
 
 
 def test_model_same_unk_and_pad(small_tokenizer: Tokenizer) -> None:


### PR DESCRIPTION
This PR fixes a bug specifically with the modernbert tokenizer. This tokenizer contains some added tokens that were not correctly taken into account in the modeldelta, thus silently corrupting it.