### PR TITLE
feat: add vocabulary padding

### DIFF
--- a/skeletoken/base.py
+++ b/skeletoken/base.py
@@ -192,6 +192,43 @@ class TokenizerModel(BaseModel):
         model._remap_added_token_ids()
         return model
 
+    def pad_vocabulary_to_multiple_of(self, token_prefix: str = "new_", n: int = 128) -> TokenizerModel:
+        """Pad the vocabulary with added tokens so its size becomes a multiple of `n`.
+
+        This is useful for GPU speedups, since embedding matrices are often more efficient
+        when their size is a multiple of a certain number (e.g. 64, 128). The padding tokens
+        are added as `AddedToken`s, so they don't become part of the merge table: they only
+        exist to resize the embedding table.
+
+        Parameters
+        ----------
+        token_prefix: str
+            The prefix used to generate padding token names: `f"{token_prefix}{i}"`.
+        n: int
+            The multiple the vocabulary size should be padded to.
+
+        Returns
+        -------
+        TokenizerModel
+            The tokenizer model with the padding tokens added.
+
+        """
+        remainder = self.vocabulary_size % n
+        if remainder == 0:
+            return self.deep_copy()
+
+        num_to_add = n - remainder
+        vocabulary = self.vocabulary
+        new_tokens: list[str] = []
+        i = 0
+        while len(new_tokens) < num_to_add:
+            candidate = f"{token_prefix}{i}"
+            if candidate not in vocabulary:
+                new_tokens.append(candidate)
+            i += 1
+
+        return self.add_addedtokens(new_tokens, is_special=True)
+
     def _turn_into_addedtoken(
         self,
         token: str,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -45,7 +45,7 @@ from skeletoken.pretokenizers import (
     WhitespacePreTokenizer,
 )
 from skeletoken.vocabulary import Vocabulary
-from tests.conftest import call_tokenizer
+from tests.conftest import assert_bpe_merges_consistent, assert_vocabulary_consistent, call_tokenizer
 
 
 def test_post_init(small_tokenizer_json: dict[str, Any]) -> None:
@@ -87,6 +87,83 @@ def test_turn_into_addedtoken(small_tokenizer: Tokenizer) -> None:
     # Should crash because it is not a regular token.
     with pytest.raises(ValueError):
         model._turn_into_addedtoken("bababbaa")
+
+
+def test_pad_vocabulary_to_multiple_of(small_tokenizer: Tokenizer) -> None:
+    """Test padding the vocabulary to a multiple of `n`."""
+    model = TokenizerModel.from_tokenizer(small_tokenizer)
+    original_size = model.vocabulary_size
+    assert original_size % 8 != 0
+
+    padded = model.pad_vocabulary_to_multiple_of(n=8)
+    assert padded.vocabulary_size % 8 == 0
+    assert padded.vocabulary_size > original_size
+
+    # The original model is untouched.
+    assert model.vocabulary_size == original_size
+
+    new_tokens = [token for token in padded.added_tokens.root if token.content.startswith("new_")]
+    assert len(new_tokens) == padded.vocabulary_size - original_size
+    for token in new_tokens:
+        assert token.special
+        assert token.content in padded.vocabulary
+
+    assert_vocabulary_consistent(padded)
+    call_tokenizer(padded)
+
+
+def test_pad_vocabulary_to_multiple_of_noop(small_tokenizer: Tokenizer) -> None:
+    """Test that no tokens are added when the vocabulary is already a multiple of `n`."""
+    model = TokenizerModel.from_tokenizer(small_tokenizer)
+    n = model.vocabulary_size
+
+    padded = model.pad_vocabulary_to_multiple_of(n=n)
+    assert padded.vocabulary_size == model.vocabulary_size
+    assert not [token for token in padded.added_tokens.root if token.content.startswith("new_")]
+
+
+def test_pad_vocabulary_to_multiple_of_skips_existing_tokens(small_tokenizer: Tokenizer) -> None:
+    """Test that padding skips candidate names that already exist in the vocabulary."""
+    model = TokenizerModel.from_tokenizer(small_tokenizer)
+    model = model.add_token_to_vocabulary("new_0", preprocess_token=False)
+    original_size = model.vocabulary_size
+
+    padded = model.pad_vocabulary_to_multiple_of(n=8)
+    new_tokens = sorted(token.content for token in padded.added_tokens.root if token.content.startswith("new_"))
+    assert "new_0" not in new_tokens
+    assert len(new_tokens) == padded.vocabulary_size - original_size
+
+    assert_vocabulary_consistent(padded)
+
+
+def test_pad_vocabulary_to_multiple_of_does_not_add_merges() -> None:
+    """Test that padding tokens are added as AddedTokens and never touch the BPE merge table."""
+    vocab_tokens = list("abcdefghijklmnop") + ["ab", "cd"]
+    bpe = BPE(
+        vocab=Vocabulary({c: i for i, c in enumerate(vocab_tokens)}),
+        merges=Merges([("a", "b"), ("c", "d")]),
+        dropout=None,
+        unk_token=None,
+        continuing_subword_prefix="",
+        end_of_word_suffix=None,
+        fuse_unk=False,
+        byte_fallback=False,
+        ignore_merges=False,
+    )
+    model = TokenizerModel(model=bpe)
+    assert isinstance(model.model, BPE)
+    original_merges = list(model.model.merges.root)
+    original_size = model.vocabulary_size
+
+    padded = model.pad_vocabulary_to_multiple_of(n=32)
+    assert padded.vocabulary_size == 32
+    assert padded.vocabulary_size > original_size
+    assert isinstance(padded.model, BPE)
+
+    assert list(padded.model.merges.root) == original_merges
+
+    assert_vocabulary_consistent(padded)
+    assert_bpe_merges_consistent(padded)
 
 
 def test_tokenizer_model_from_tokenizer(small_tokenizer: Tokenizer) -> None:


### PR DESCRIPTION
This PR adds vocabulary padding. It allows you to pad the vocabulary of a tokenizer to a multiple of something.