### PR TITLE
fix: remap hard-coded token ids after removing tokens

### DIFF
--- a/skeletoken/base.py
+++ b/skeletoken/base.py
@@ -379,12 +379,13 @@ class TokenizerModel(BaseModel):
 
     def _remap_added_token_ids(self) -> None:
         """Remap the IDs of added tokens to match the vocabulary."""
-        model_delta = self.model_delta
-        remapping = {old_id: new_id for new_id, old_id in model_delta.token_mapping.items()}
+        # Added tokens are ordinary vocabulary entries, so the vocabulary is the authoritative
+        # source for their ids. `model_delta` is not usable here: it is computed against
+        # `_original_tokenizer`, so its ids only line up with `token.id` for a model that is a
+        # single edit away from the original.
+        vocabulary = self.model.vocab.vocabulary
         for token in self.added_tokens.root:
-            remapped = model_delta.new_tokens.get(token.content)
-            if remapped is None:
-                remapped = remapping.get(token.id, token.id)
+            remapped = vocabulary[token.content]
             if token.id != remapped:
                 logger.info(f"Remapping ID of added token '{token.content}' from {token.id} to {remapped}.")
                 token.id = remapped
@@ -443,6 +444,9 @@ class TokenizerModel(BaseModel):
         for token in tokens:
             self.added_tokens.maybe_remove_token(token)
         self.model.remove_tokens(tokens)
+        # Removal compacts the vocabulary, so the ids hard-coded elsewhere (added tokens,
+        # `padding.pad_id`, the post-processor's special tokens) have to follow.
+        self._remap_added_token_ids()
 
         return self
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1018,6 +1018,50 @@ def test_batch_remove_tokens(small_tokenizer: Tokenizer) -> None:
     call_tokenizer(model)
 
 
+def _model_with_hardcoded_ids(small_tokenizer_json: dict[str, Any]) -> TokenizerModel:
+    """Build a model that hard-codes token ids in its padding and post-processor."""
+    model = TokenizerModel.from_string(json.dumps(small_tokenizer_json))
+    model.pad_token = "[MASK]"
+    return model.add_post_processor(TemplatePostProcessor.from_tokens(None, ("F", model.vocabulary["F"])))
+
+
+def test_remove_tokens_remaps_hardcoded_ids(small_tokenizer_json: dict[str, Any]) -> None:
+    """Test that removing tokens moves the ids hard-coded outside the vocabulary."""
+    model = _model_with_hardcoded_ids(small_tokenizer_json)
+    assert model.vocabulary["F"] == 10
+    assert model.pad_token_id == 4
+
+    model = model.remove_tokens_from_vocabulary(["[PAD]", "[SEP]"])
+
+    # Both tokens sat below "[MASK]" and "F", so both ids shift down by two.
+    assert model.vocabulary["F"] == 8
+    assert model.pad_token_id == 2
+    assert isinstance(model.post_processor, TemplatePostProcessor)
+    assert model.post_processor.special_tokens["F"].ids == [8]
+    assert_vocabulary_consistent(model)
+
+    # The symptom this guards against: an id pointing past the end of the vocabulary.
+    assert max(model.to_tokenizer().encode("a b c").ids) < model.vocabulary_size
+
+    call_tokenizer(model)
+
+
+def test_remove_tokens_remaps_hardcoded_ids_when_chained(small_tokenizer_json: dict[str, Any]) -> None:
+    """Test that removing tokens one at a time gives the same ids as removing them at once."""
+    model = _model_with_hardcoded_ids(small_tokenizer_json)
+
+    at_once = model.remove_tokens_from_vocabulary(["[PAD]", "[SEP]"])
+    chained = model.remove_token_from_vocabulary("[PAD]").remove_token_from_vocabulary("[SEP]")
+
+    assert chained.vocabulary == at_once.vocabulary
+    assert chained.added_tokens.root == at_once.added_tokens.root
+    assert chained.pad_token_id == at_once.pad_token_id
+    assert chained.post_processor == at_once.post_processor
+    assert_vocabulary_consistent(chained)
+
+    call_tokenizer(chained)
+
+
 def test_remove_uppercase(small_tokenizer: Tokenizer) -> None:
     """Test the removal of uppercase tokens from the vocabulary."""
     model = TokenizerModel.from_tokenizer(small_tokenizer)


### PR DESCRIPTION
Fixes #93.

## What goes wrong

`remove_tokens_from_vocabulary` compacts the vocabulary and drops the removed entries from `added_tokens`, but the ids that other components hard-code — the post-processor's `special_tokens[*].ids` and `padding.pad_id` — keep pointing at the pre-removal vocabulary. The tokenizer then emits ids past the end of its own vocabulary, and nothing along the way complains.

## The fix

Two parts.

**1. Call `_remap_added_token_ids()` at the end of `_remove_tokens_from_vocabulary`.** That method already does exactly the repair that is needed, and `_consolidate` already calls it after its own reindexing. The removal path just never did.

**2. Make `_remap_added_token_ids` take the ids from the vocabulary rather than from `model_delta`.**

The first part on its own is not enough. `model_delta` is computed against `_original_tokenizer`, so `remapping.get(token.id, token.id)` only means anything while `token.id` is still an id in the *original* vocabulary — i.e. for a model that is a single edit away from the original. Removing twice breaks that assumption:

```python
model.remove_tokens_from_vocabulary(["a"]).remove_tokens_from_vocabulary(["b"])
```

With only part 1, the second removal looks `<eos>`'s already-remapped id up in a mapping keyed by original ids and lands it on 3, which `<pad>` occupies. Added tokens are ordinary vocabulary entries, so reading the id straight out of the vocabulary is both authoritative and idempotent, and it is what `model_post_init` already does when it assigns added token ids on load.

## The reproducer from the issue

```python
import json

from skeletoken import TokenizerModel
from tokenizers import Tokenizer, models, pre_tokenizers, processors
from transformers import PreTrainedTokenizerFast

vocab = {char: index for index, char in enumerate("abcde")}
tokenizer = Tokenizer(models.BPE(vocab=vocab, merges=[]))
tokenizer.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False)
tokenizer.add_special_tokens(["<pad>", "<eos>"])
tokenizer.post_processor = processors.TemplateProcessing(
    single="$A <eos>", pair="$A $B", special_tokens=[("<eos>", 6)]
)
wrapped = PreTrainedTokenizerFast(tokenizer_object=tokenizer, eos_token="<eos>", pad_token="<pad>")
wrapped.backend_tokenizer.enable_padding(pad_id=5, pad_token="<pad>")

model = TokenizerModel.from_transformers_tokenizer(wrapped)
trimmed = model.remove_tokens_from_vocabulary(["a", "b"])
document = json.loads(trimmed.to_tokenizer().to_str())

print("vocabulary_size:", trimmed.vocabulary_size)
print("post_processor :", document["post_processor"]["special_tokens"])
print("padding.pad_id :", document["padding"]["pad_id"])
print("encode('cde')  :", trimmed.to_tokenizer().encode("cde").ids)
```

On `main`:

```
vocabulary_size: 5
post_processor : {'<eos>': {'id': '<eos>', 'ids': [6], 'tokens': ['<eos>']}}
padding.pad_id : 5
encode('cde')  : [0, 1, 2, 6]
```

With this branch:

```
vocabulary_size: 5
post_processor : {'<eos>': {'id': '<eos>', 'ids': [4], 'tokens': ['<eos>']}}
padding.pad_id : 3
encode('cde')  : [0, 1, 2, 4]
```

Chaining the two removals gives the same result, which it did not before.

## Tests

Two tests in `tests/test_base.py`, both of which fail on `main`:

- `test_remove_tokens_remaps_hardcoded_ids` removes two tokens that sit below the padding token and a post-processor special token, and checks that all three ids move along. It also asserts that no encoded id points past the end of the vocabulary, which is the symptom users actually hit.
- `test_remove_tokens_remaps_hardcoded_ids_when_chained` checks that removing the two tokens one at a time gives the same model as removing them in a single call.

Both reuse `assert_vocabulary_consistent` from `tests/conftest.py`, which already asserts most of the invariant.

## Checks

- `make test`: 293 passed, coverage still 100%.
- `ruff check` and `ruff format` clean, `mypy skeletoken` clean.
- `ty check skeletoken` reports the same 21 diagnostics as on `main`, none of them new.
- `tests/integration` passes for the cases that run offline (I skipped the model2vec / sentence-transformers / pylate ones).

## Left out on purpose

The issue also suggested having `to_tokenizer()` reject a document that contains a hard-coded id `>= vocabulary_size`. I did not add that here. It would turn tokenizers that already carry this problem into a hard error at construction, which seems like your call rather than mine. Happy to add it in a follow-up if you want it.
